### PR TITLE
Fix Sensor Namespace issue

### DIFF
--- a/src/Actuators/Actuator.h
+++ b/src/Actuators/Actuator.h
@@ -8,8 +8,7 @@ namespace mmfs
 
 enum ActuatorType
 {
-    SERVO_,
-    UNKNOWN_
+    SERVO_
 };
 class Actuator
 {

--- a/src/Sensors/Sensor.h
+++ b/src/Sensors/Sensor.h
@@ -4,59 +4,61 @@
 #include "../RecordData/RecordData.h"
 #include "../Constants.h"
 
-enum SensorType
+namespace mmfs
 {
-    BAROMETER_,
-    GPS_,
-    IMU_,
-    LIGHT_SENSOR_,
-    RADIO_,
-    RTC_,
-    ENCODER_,
-    UNKNOWN_
-};
-class Sensor
-{
-public:
-    virtual ~Sensor()
+    enum SensorType
     {
-        delete[] data;
-        delete[] staticData;
-        delete[] name;
+        BAROMETER_,
+        GPS_,
+        IMU_,
+        LIGHT_SENSOR_,
+        RADIO_,
+        RTC_,
+        ENCODER_
     };
-    // Sets up the sensor and stores any critical parameters
-    virtual bool initialize() = 0;
-    // gives the names of the columns which transient data will be stored under, in a comma separated string
-    virtual const char *getCsvHeader() const = 0;
-    // gives the data values of the variables said to be stored by the header, in the same order, in a comma separated string
-    virtual const char *getDataString() const = 0;
-    // gives a string which includes all the sensor's static/initialization data. This will be in the format of dataName:dataValue, with each pair separated by a newline (\n)
-    virtual const char *getStaticDataString() const = 0;
-
-    virtual SensorType getType() const = 0;              // Returns the type of the sensor
-    virtual const char *getTypeString() const = 0;       // Returns the type of the sensor as a string
-    virtual const char *getName() const { return name; } // Returns the name of the sensor
-    virtual void setName(const char *n)                  // Sets the name of the sensor
+    class Sensor
     {
-        delete[] name;
-        int len = strlen(n);
-        name = new char[len + 1];
-        snprintf(name, len + 1, "%s", n);
-    }
+    public:
+        virtual ~Sensor()
+        {
+            delete[] data;
+            delete[] staticData;
+            delete[] name;
+        };
+        // Sets up the sensor and stores any critical parameters
+        virtual bool initialize() = 0;
+        // gives the names of the columns which transient data will be stored under, in a comma separated string
+        virtual const char *getCsvHeader() const = 0;
+        // gives the data values of the variables said to be stored by the header, in the same order, in a comma separated string
+        virtual const char *getDataString() const = 0;
+        // gives a string which includes all the sensor's static/initialization data. This will be in the format of dataName:dataValue, with each pair separated by a newline (\n)
+        virtual const char *getStaticDataString() const = 0;
 
-    virtual void update() = 0; // Updates the sensor's fields by querying the sensor for new data
+        virtual SensorType getType() const = 0;              // Returns the type of the sensor
+        virtual const char *getTypeString() const = 0;       // Returns the type of the sensor as a string
+        virtual const char *getName() const { return name; } // Returns the name of the sensor
+        virtual void setName(const char *n)                  // Sets the name of the sensor
+        {
+            delete[] name;
+            int len = strlen(n);
+            name = new char[len + 1];
+            snprintf(name, len + 1, "%s", n);
+        }
 
-    virtual bool isInitialized() const { return initialized; } // Returns whether the sensor has been initialized or not
+        virtual void update() = 0; // Updates the sensor's fields by querying the sensor for new data
 
-    virtual explicit operator bool() const { return initialized; } // Returns whether the sensor has been initialized or not
+        virtual bool isInitialized() const { return initialized; } // Returns whether the sensor has been initialized or not
 
-    virtual void setBiasCorrectionMode(bool mode) { biasCorrectionMode = mode; } // Sets the bias correction mode of the sensor
-protected:
-    bool initialized = false;
-    bool biasCorrectionMode = true;
-    char *name = nullptr;       // Name of the sensor
-    char *staticData = nullptr; // Initial "power on" data
-    char *data = nullptr;       // Transient data
-};
+        virtual explicit operator bool() const { return initialized; } // Returns whether the sensor has been initialized or not
+
+        virtual void setBiasCorrectionMode(bool mode) { biasCorrectionMode = mode; } // Sets the bias correction mode of the sensor
+    protected:
+        bool initialized = false;
+        bool biasCorrectionMode = true;
+        char *name = nullptr;       // Name of the sensor
+        char *staticData = nullptr; // Initial "power on" data
+        char *data = nullptr;       // Transient data
+    };
+}; // namespace mmfs
 
 #endif // SENSOR_H

--- a/src/Sensors/Sensor.h
+++ b/src/Sensors/Sensor.h
@@ -6,7 +6,7 @@
 
 namespace mmfs
 {
-    enum SensorType
+    enum SensorType // These have trailing underscores to avoid conflicts with the same names in other libraries *cough* IMU *cough*
     {
         BAROMETER_,
         GPS_,


### PR DESCRIPTION
Adds `Sensor` to `mmfs` namespace.

Also removes `UNKNOWN_` type from the `SensorType` and `ActuatorType` enums, because I got an error that they conflicted with each other. At the end of the day, we shouldn't have any unknown types.