### PR TITLE
Added bias correction option

### DIFF
--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -28,7 +28,7 @@ namespace mmfs
 
 #pragma endregion
 
-    bool State::init()
+    bool State::init(bool useBiasCorrection)
     {
         char *logData = new char[100];
         int good = 0, tryNumSensors = 0;
@@ -37,7 +37,7 @@ namespace mmfs
             if (sensors[i])
             {
                 tryNumSensors++;
-                if (sensors[i]->begin())
+                if (sensors[i]->begin(useBiasCorrection))
                 {
                     good++;
                     snprintf(logData, 100, "%s [%s] initialized.", sensors[i]->getTypeString(), sensors[i]->getName());

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -31,7 +31,8 @@ namespace mmfs
 
         // to be called after all applicable sensors have been added.
         // Returns false if any sensor failed to init. Check data log for failed sensor. Disables sensor if failed.
-        virtual bool init();
+        // useBiasCorrection: whether or not to use bias correction. If true, the override class for State must implement markLiftoff() to disable bias correction.
+        virtual bool init(bool useBiasCorrection = false);
 
         // Updates the state with the most recent sensor data. CurrentTime is the time in seconds since the uC was turned on. If not provided, the state will use the current time.
         virtual void updateState(double currentTime = -1);


### PR DESCRIPTION
Just added a parameter to the `init()` call for State, to give option to use bias correction or not, as if they're using it they explicitly need to call the method to set it to false in their state code, which they may not know do. I think it's better to make it so that the bias correction is only applied if they know so, and thus know they'll be turning it off.