### PR TITLE
Bias correction globals fix

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -21,8 +21,6 @@ AvionicsKF kfilter;
 Logger logger;
 AvionicsState avionicsState(sensors, 3, &kfilter);
 
-const int SENSOR_BIAS_CORRECTION_DATA_LENGTH = 2;
-const int SENSOR_BIAS_CORRECTION_DATA_IGNORE = 1;
 const int UPDATE_RATE = 10;
 const int UPDATE_INTERVAL = 1000.0 / UPDATE_RATE;
 
@@ -30,6 +28,9 @@ const int UPDATE_INTERVAL = 1000.0 / UPDATE_RATE;
 
 void setup()
 {
+    //If you need to change these values, do that here (in setup, before anything else)
+    //SENSOR_BIAS_CORRECTION_DATA_LENGTH = 2;
+    //SENSOR_BIAS_CORRECTION_DATA_IGNORE = 1;
 
     logger.init();
 

--- a/lib/NativeTestMocks/NativeTestHelper.cpp
+++ b/lib/NativeTestMocks/NativeTestHelper.cpp
@@ -7,7 +7,5 @@ BlinkBuzz bb(allowed_pins, 2, true);
 mmfs::Logger logger;
 
 const int UPDATE_RATE = 10;
-const int SENSOR_BIAS_CORRECTION_DATA_IGNORE = 1;
-const int SENSOR_BIAS_CORRECTION_DATA_LENGTH = 2;
 const int UPDATE_INTERVAL = 1.0 / UPDATE_RATE * 1000;
 const int BUZZER_PIN = 14;

--- a/lib/NativeTestMocks/NativeTestHelper.h
+++ b/lib/NativeTestMocks/NativeTestHelper.h
@@ -14,10 +14,4 @@ extern int allowed_pins[];
 extern BlinkBuzz bb;
 extern mmfs::Logger logger;
 
-extern const int UPDATE_RATE;
-extern const int SENSOR_BIAS_CORRECTION_DATA_IGNORE;
-extern const int SENSOR_BIAS_CORRECTION_DATA_LENGTH;
-extern const int UPDATE_INTERVAL;
-extern const int BUZZER_PIN;
-
 #endif // NATIVE_TEST_HELPER_H

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -17,8 +17,8 @@ constexpr int MAX_DIGITS_LAT_LON = 12; // 180.0000000
 extern const int BUZZER_PIN;
 extern const int BUILTIN_LED_PIN;
 constexpr double MEAN_SEA_LEVEL_PRESSURE_HPA = 1013.25;
-extern const int SENSOR_BIAS_CORRECTION_DATA_LENGTH; // in seconds
-extern const int SENSOR_BIAS_CORRECTION_DATA_IGNORE; // in seconds (how many seconds to ignore the most recent data for bias correction)
+inline int SENSOR_BIAS_CORRECTION_DATA_LENGTH = 2; // in seconds
+inline int SENSOR_BIAS_CORRECTION_DATA_IGNORE = 1; // in seconds (how many seconds to ignore the most recent data for bias correction)
 
 // ------------------------------------------------------
 

--- a/test/test_misc/test_misc.cpp
+++ b/test/test_misc/test_misc.cpp
@@ -1,0 +1,60 @@
+#include <unity.h>
+#include "../../lib/NativeTestMocks/NativeTestHelper.h"
+
+// include other headers you need to test here
+
+#include "../../src/Constants.h"
+
+// ---
+
+// Set up and global variables or mocks for testing here
+
+
+
+// ---
+
+// These two functions are called before and after each test function, and are required in unity, even if empty.
+void setUp(void)
+{
+    // set stuff up before each test here, if needed
+}
+
+void tearDown(void)
+{
+    // clean stuff up after each test here, if needed
+}
+// ---
+
+// Test functions must be void and take no arguments, put them here
+
+// void test_function_name() {
+//     TEST_ASSERT_EQUAL(expected, actual);
+//     TEST_ASSERT_EQUAL_FLOAT(expected, actual);
+// }
+
+//verify redefining of constants
+
+void test_constants() {
+
+    SENSOR_BIAS_CORRECTION_DATA_LENGTH = 10;
+    SENSOR_BIAS_CORRECTION_DATA_IGNORE = 50;
+    
+    TEST_ASSERT_EQUAL_INT(10, SENSOR_BIAS_CORRECTION_DATA_LENGTH);
+    TEST_ASSERT_EQUAL_INT(50, SENSOR_BIAS_CORRECTION_DATA_IGNORE);
+}
+
+// ---
+
+// This is the main function that runs all the tests. It should be the last thing in the file.
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+
+    // Add your tests here
+    // RUN_TEST(test_function_name); // no parentheses after function name
+
+    UNITY_END();
+
+    return 0;
+}
+// ---

--- a/test/test_misc/test_misc.cpp
+++ b/test/test_misc/test_misc.cpp
@@ -52,6 +52,7 @@ int main(int argc, char **argv)
 
     // Add your tests here
     // RUN_TEST(test_function_name); // no parentheses after function name
+    RUN_TEST(test_constants);
 
     UNITY_END();
 


### PR DESCRIPTION
Changed these "constants" to be inline variables and no longer be constant. This allows users to override them if they need to, but not need to define them if they don't need to. I really prefer to stay away from `#define`s.

Note that you need to have gcc >7.0 to compile inline variables (they're on v13 now, 7 is from before c++17. Probably time to upgrade if you haven't yet.)