### PR TITLE
Error Unit Tests

### DIFF
--- a/lib/NativeTestMocks/NativeTestHelper.cpp
+++ b/lib/NativeTestMocks/NativeTestHelper.cpp
@@ -1,10 +1,11 @@
 #include "NativeTestHelper.h"
 
-uint8_t external_psram_size = 0;
+uint8_t external_psram_size = 1;
 
 int allowed_pins[] = {13, 33};
 BlinkBuzz bb(allowed_pins, 2, true);
 mmfs::Logger logger;
+mmfs::ErrorHandler errorHandler(&logger);
 
 const int UPDATE_RATE = 10;
 const int SENSOR_BIAS_CORRECTION_DATA_IGNORE = 1;

--- a/lib/NativeTestMocks/NativeTestHelper.h
+++ b/lib/NativeTestMocks/NativeTestHelper.h
@@ -5,6 +5,7 @@
 #include "../../src/Constants.h"
 #include "../../src/BlinkBuzz/BlinkBuzz.h"
 #include "../../src/RecordData/Logger.h"
+#include "../../src/Error/ErrorHandler.h"
 #include <string>
 #include <unity.h>
 
@@ -13,6 +14,7 @@
 extern int allowed_pins[];
 extern BlinkBuzz bb;
 extern mmfs::Logger logger;
+extern mmfs::ErrorHandler errorHandler;
 
 extern const int UPDATE_RATE;
 extern const int SENSOR_BIAS_CORRECTION_DATA_IGNORE;

--- a/src/Error/ErrorHandler.cpp
+++ b/src/Error/ErrorHandler.cpp
@@ -12,7 +12,7 @@ Error::Error(ErrorType type, const char *message, int errorLocation)
 
 Error::~Error()
 {
-    delete[] message;
+
 }
 
 const char *Error::getTypeString() const

--- a/test/test_error/test_error.cpp
+++ b/test/test_error/test_error.cpp
@@ -1,0 +1,90 @@
+#include <unity.h>
+#include "../../lib/NativeTestMocks/NativeTestHelper.h"
+
+// include other headers you need to test here
+
+#include "../../src/Error/ErrorHandler.h"
+
+// ---
+
+// Set up and global variables or mocks for testing here
+
+// ---
+
+// These two functions are called before and after each test function, and are required in unity, even if empty.
+void setUp(void)
+{
+    // set stuff up before each test here, if needed
+}
+
+void tearDown(void)
+{
+    // clean stuff up after each test here, if needed
+}
+// ---
+
+// Test functions must be void and take no arguments, put them here
+
+// void test_function_name() {
+//     TEST_ASSERT_EQUAL(expected, actual);
+//     TEST_ASSERT_EQUAL_FLOAT(expected, actual);
+// }
+
+void test_error_add() {
+    // ErrorType type, const char *message, int errorLocation
+    errorHandler.addError(mmfs::ErrorType::CRITICAL_ERROR, "Test error message", 0);
+    mmfs::Error *error = errorHandler.getFirstError();
+    TEST_ASSERT_NOT_NULL(error);
+    TEST_ASSERT_EQUAL(mmfs::ErrorType::CRITICAL_ERROR, error->type);
+    TEST_ASSERT_EQUAL_STRING("Test error message", error->getMessage());
+    TEST_ASSERT_EQUAL(0, error->getErrorLocation());
+}
+
+void test_error_add_no_location() {
+    // ErrorType type, const char *message
+    errorHandler.addError(mmfs::ErrorType::NONCRITICAL_WARNING, "Test error message 2");
+    mmfs::Error *error = errorHandler.getLastError();
+    TEST_ASSERT_NOT_NULL(error);
+    TEST_ASSERT_EQUAL(mmfs::ErrorType::NONCRITICAL_WARNING, error->type);
+    TEST_ASSERT_EQUAL_STRING("Test error message 2", error->getMessage());
+    TEST_ASSERT_EQUAL(-1, error->getErrorLocation());
+}
+
+void test_error_add_existing() {
+    // Error *error
+    mmfs::Error *error = new mmfs::Error(mmfs::ErrorType::HARDWARE_ERROR, "Test error message 3", 5);
+    errorHandler.addError(error);
+    mmfs::Error *error2 = errorHandler.getLastError();
+    TEST_ASSERT_NOT_NULL(error2);
+    TEST_ASSERT_EQUAL(mmfs::ErrorType::HARDWARE_ERROR, error2->type);
+    TEST_ASSERT_EQUAL_STRING("Test error message 3", error2->getMessage());
+    TEST_ASSERT_EQUAL(5, error2->getErrorLocation());
+}
+
+void test_error_to_string() {
+    // Error *error
+    mmfs::Error *error = new mmfs::Error(mmfs::ErrorType::SOFTWARE_ERROR, "Test error message 4", 515);
+    TEST_ASSERT_EQUAL_STRING("SOFTWARE_ERROR: Test error message 4 at 515", error->toString());
+    delete error;
+}
+
+// ---
+
+// This is the main function that runs all the tests. It should be the last thing in the file.
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+
+    // Add your tests here
+    // RUN_TEST(test_function_name); // no parentheses after function name
+    RUN_TEST(test_error_add);
+    RUN_TEST(test_error_add_no_location);
+    RUN_TEST(test_error_add_existing);
+    RUN_TEST(test_error_to_string);
+
+
+    UNITY_END();
+
+    return 0;
+}
+// ---


### PR DESCRIPTION
Added a few unit tests here. There's not that much to this class so there aren't that many tests. They are a bit fragile, for example if we change the format of the error output string, then the test to make sure that works would also have to change. Not sure there's  really a way around it, but I suppose it's probably for the best so that whoever might make that change can verify it outputs how they expect it to.