### PR TITLE
Encoder naming

### DIFF
--- a/src/MMFS.h
+++ b/src/MMFS.h
@@ -8,7 +8,7 @@
 #include "Sensors/GPS/MAX_M10S.h"
 #include "Sensors/LightSensor/LightSensor.h"
 #include "Sensors/Baro/BMP280.h"
-#include "Sensors/Encoder/Encoder.h"
+#include "Sensors/Encoder/Encoder_MMFS.h"
 #include "State/State.h"
 #include "Constants.h"
 #include "Filters/LinearKalmanFilter.h"

--- a/src/MMFS.h
+++ b/src/MMFS.h
@@ -8,6 +8,7 @@
 #include "Sensors/GPS/MAX_M10S.h"
 #include "Sensors/LightSensor/LightSensor.h"
 #include "Sensors/Baro/BMP280.h"
+#include "Sensors/Encoder/Encoder.h"
 #include "State/State.h"
 #include "Constants.h"
 #include "Filters/LinearKalmanFilter.h"

--- a/src/Sensors/Encoder/Encoder_MMFS.cpp
+++ b/src/Sensors/Encoder/Encoder_MMFS.cpp
@@ -13,7 +13,7 @@ namespace mmfs
         // Additional constructor logic
     }
 
-    double Encoder_MMFS::getSteps() const { return currentRelativeSteps; }
+    int Encoder_MMFS::getSteps() const { return currentRelativeSteps; }
 
 #pragma endregion // Encoder Specific Functions
 

--- a/src/Sensors/Encoder/Encoder_MMFS.cpp
+++ b/src/Sensors/Encoder/Encoder_MMFS.cpp
@@ -1,13 +1,13 @@
-#include "Encoder.h"
+#include "Encoder_MMFS.h"
 
 namespace mmfs
 {
 
 #pragma region Encoder Specific Functions
 
-    Encoder::~Encoder() {}
+    Encoder_MMFS::~Encoder_MMFS() {}
 
-    Encoder::Encoder()
+    Encoder_MMFS::Encoder_MMFS()
     {
         setUpPackedData();
         // Additional constructor logic
@@ -17,13 +17,13 @@ namespace mmfs
 
 #pragma region Sensor Virtual Function Implementations
 
-    void Encoder::update()
+    void Encoder_MMFS::update()
     {
         read();
         packData();
     }
 
-    bool Encoder::begin(bool useBiasCorrection)
+    bool Encoder_MMFS::begin(bool useBiasCorrection)
     {
         biasCorrectionMode = useBiasCorrection;
         return init();
@@ -31,31 +31,31 @@ namespace mmfs
 
 #pragma region Data Reporting
 
-    const char *Encoder::getTypeString() const { return "Encoder"; }
+    const char *Encoder_MMFS::getTypeString() const { return "Encoder"; }
 
-    const SensorType Encoder::getType() const { return ENCODER_; }
+    const SensorType Encoder_MMFS::getType() const { return ENCODER_; }
 
-    const int Encoder::getNumPackedDataPoints() const { return 1; }
+    const int Encoder_MMFS::getNumPackedDataPoints() const { return 1; }
 
-    const PackedType *Encoder::getPackedOrder() const
+    const PackedType *Encoder_MMFS::getPackedOrder() const
     {
         static const PackedType order[] = {INT};
         return order;
     }
 
-    const char **Encoder::getPackedDataLabels() const
+    const char **Encoder_MMFS::getPackedDataLabels() const
     {
         static const char *labels[] = {"Rel Steps"};
         return labels;
     }
 
-    void Encoder::packData()
+    void Encoder_MMFS::packData()
     {
         int offset = 0;
         memcpy(packedData + offset, &currentRelativeSteps, sizeof(int));
     }
 
-    // const char *Encoder::getStaticDataString() const
+    // const char *Encoder_MMFS::getStaticDataString() const
     // {
     //     sprintf(staticData, "Initial Steps: %d\n", initialSteps);
     //     return staticData;

--- a/src/Sensors/Encoder/Encoder_MMFS.cpp
+++ b/src/Sensors/Encoder/Encoder_MMFS.cpp
@@ -13,6 +13,8 @@ namespace mmfs
         // Additional constructor logic
     }
 
+    double Encoder_MMFS::getSteps() const { return currentRelativeSteps; }
+
 #pragma endregion // Encoder Specific Functions
 
 #pragma region Sensor Virtual Function Implementations

--- a/src/Sensors/Encoder/Encoder_MMFS.h
+++ b/src/Sensors/Encoder/Encoder_MMFS.h
@@ -10,7 +10,7 @@ namespace mmfs
     {
     public:
         virtual ~Encoder_MMFS();
-        virtual double getSteps() const;
+        virtual int getSteps() const;
         virtual const char *getTypeString() const override;
         virtual const SensorType getType() const override;
         virtual void update() override;

--- a/src/Sensors/Encoder/Encoder_MMFS.h
+++ b/src/Sensors/Encoder/Encoder_MMFS.h
@@ -1,15 +1,15 @@
-#ifndef ENCODER_H
-#define ENCODER_H
+#ifndef ENCODER_MMFS_H
+#define ENCODER_MMFS_H
 
 #include "../Sensor.h"
 #include "../../Constants.h"
 
 namespace mmfs
 {
-    class Encoder : Sensor
+    class Encoder_MMFS : Sensor
     {
     public:
-        virtual ~Encoder();
+        virtual ~Encoder_MMFS();
         virtual const char *getTypeString() const override;
         virtual const SensorType getType() const override;
         virtual void update() override;
@@ -20,9 +20,9 @@ namespace mmfs
         virtual void packData();
 
     protected:
-        Encoder();
+        Encoder_MMFS();
         int currentRelativeSteps;
         int initialSteps;
     };
 }
-#endif // ENCODER_H
+#endif // ENCODER_MMFS_H

--- a/src/Sensors/Encoder/Encoder_MMFS.h
+++ b/src/Sensors/Encoder/Encoder_MMFS.h
@@ -10,6 +10,7 @@ namespace mmfs
     {
     public:
         virtual ~Encoder_MMFS();
+        virtual double getSteps() const;
         virtual const char *getTypeString() const override;
         virtual const SensorType getType() const override;
         virtual void update() override;

--- a/src/Sensors/Encoder/Encoder_MMFS.h
+++ b/src/Sensors/Encoder/Encoder_MMFS.h
@@ -6,7 +6,7 @@
 
 namespace mmfs
 {
-    class Encoder_MMFS : Sensor
+    class Encoder_MMFS : public Sensor
     {
     public:
         virtual ~Encoder_MMFS();


### PR DESCRIPTION
- Changed encoder name to encoder_mmfs due to another library having a class named encoder
- made encoder inherit a public sensor