### PR TITLE
136 rework sensortype stuff

### DIFF
--- a/examples/Avionics/AvionicsState.cpp
+++ b/examples/Avionics/AvionicsState.cpp
@@ -20,9 +20,9 @@ void AvionicsState::updateState(double newTime)
 void AvionicsState::determineStage()
 {
     int timeSinceLaunch = currentTime - timeOfLaunch;
-    IMU *imu = reinterpret_cast<IMU *>(getSensor(IMU_));
-    Barometer *baro = reinterpret_cast<Barometer *>(getSensor(BAROMETER_));
-    //GPS *gps = reinterpret_cast<GPS *>(getSensor(GPS_));
+    // GPS *gps = reinterpret_cast<GPS *>(getSensor("GPS"_i));
+    IMU *imu = reinterpret_cast<IMU *>(getSensor("IMU"_i));
+    Barometer *baro = reinterpret_cast<Barometer *>(getSensor("Barometer"_i));
     if (stage == 0 &&
         (sensorOK(imu) || sensorOK(baro)) &&
         (sensorOK(imu) ? abs(imu->getAccelerationGlobal().z()) > 25 : true) &&

--- a/src/Events/Event.h
+++ b/src/Events/Event.h
@@ -1,8 +1,7 @@
 #ifndef EVENT_H
 #define EVENT_H
 
-#include <stdint.h>
-#include <stddef.h>
+#include "../Utils/Hash.h"
 
 /*
  * The hash method at the top of this file is a way to change string literals to integers at compile time,
@@ -14,21 +13,6 @@
 namespace mmfs
 {
     using EventID = uint32_t;
-
-    constexpr uint32_t fnv1a_32(const char *s, size_t count)
-    {
-        uint32_t hash = 2166136261u;
-        for (size_t i = 0; i < count; i++)
-        {
-            hash ^= static_cast<unsigned char>(s[i]);
-            hash *= 16777619u;
-        }
-        return hash;
-    }
-    constexpr EventID operator"" _i(const char *str, size_t len)
-    {
-        return fnv1a_32(str, len);
-    }
 
     // Forward-declare EventManager
     class EventManager;

--- a/src/Sensors/Baro/Barometer.cpp
+++ b/src/Sensors/Baro/Barometer.cpp
@@ -5,7 +5,7 @@ namespace mmfs
 {
 
 #pragma region Barometer Specific Functions
-    Barometer::Barometer()
+    Barometer::Barometer() : Sensor("Barometer")
     {
         addColumn(DOUBLE, &pressure, "Pres (hPa)");
         addColumn(DOUBLE, &temp, "Temp (C)");
@@ -40,10 +40,6 @@ namespace mmfs
 #pragma endregion // Barometer Specific Functions
 
 #pragma region Sensor Virtual Function Implementations
-
-    const char *Barometer::getTypeString() const { return "Barometer"; }
-
-    const SensorType Barometer::getType() const { return "Barometer"_i; }
 
     void Barometer::update()
     {

--- a/src/Sensors/Baro/Barometer.cpp
+++ b/src/Sensors/Baro/Barometer.cpp
@@ -43,7 +43,7 @@ namespace mmfs
 
     const char *Barometer::getTypeString() const { return "Barometer"; }
 
-    const SensorType Barometer::getType() const { return BAROMETER_; }
+    const SensorType Barometer::getType() const { return "Barometer"_i; }
 
     void Barometer::update()
     {

--- a/src/Sensors/Baro/Barometer.h
+++ b/src/Sensors/Baro/Barometer.h
@@ -19,8 +19,6 @@ namespace mmfs
         virtual double getAGLAltFt() const;
 
         // Sensor virtual functions
-        virtual const char *getTypeString() const override;
-        virtual const SensorType getType() const override;
         virtual void update() override;
         virtual bool begin(bool useBiasCorrection = true) override;
 
@@ -36,7 +34,7 @@ namespace mmfs
         double groundAltitude = 0;
 
         CircBuffer<double> pressureBuffer = CircBuffer<double>(CIRC_BUFFER_LENGTH);
-        
+
         double calcAltitude(double pressure);
     };
 }

--- a/src/Sensors/Baro/Barometer.h
+++ b/src/Sensors/Baro/Barometer.h
@@ -36,7 +36,7 @@ namespace mmfs
         double groundAltitude = 0;
 
         CircBuffer<double> pressureBuffer = CircBuffer<double>(CIRC_BUFFER_LENGTH);
-
+        
         double calcAltitude(double pressure);
     };
 }

--- a/src/Sensors/Encoder/Encoder_MMFS.cpp
+++ b/src/Sensors/Encoder/Encoder_MMFS.cpp
@@ -7,7 +7,7 @@ namespace mmfs
 
     Encoder_MMFS::~Encoder_MMFS() {}
 
-    Encoder_MMFS::Encoder_MMFS()
+    Encoder_MMFS::Encoder_MMFS() : Sensor("Encoder")
     {
         addColumn(INT, &currentRelativeSteps, "Rel Steps");
     }
@@ -36,10 +36,6 @@ namespace mmfs
     }
 
 #pragma region Data Reporting
-
-    const char *Encoder_MMFS::getTypeString() const { return "Encoder"; }
-
-    const SensorType Encoder_MMFS::getType() const { return "Encoder"_i; }
 
 #pragma endregion // Data Reporting
 

--- a/src/Sensors/Encoder/Encoder_MMFS.cpp
+++ b/src/Sensors/Encoder/Encoder_MMFS.cpp
@@ -39,7 +39,7 @@ namespace mmfs
 
     const char *Encoder_MMFS::getTypeString() const { return "Encoder"; }
 
-    const SensorType Encoder_MMFS::getType() const { return ENCODER_; }
+    const SensorType Encoder_MMFS::getType() const { return "Encoder"_i; }
 
 #pragma endregion // Data Reporting
 

--- a/src/Sensors/Encoder/Encoder_MMFS.h
+++ b/src/Sensors/Encoder/Encoder_MMFS.h
@@ -12,8 +12,6 @@ namespace mmfs
     public:
         virtual ~Encoder_MMFS();
         virtual int getSteps() const;
-        virtual const char *getTypeString() const override;
-        virtual const SensorType getType() const override;
         virtual void update() override;
         virtual bool begin(bool useBiasCorrection = true) override;
         virtual void setInitialSteps(int step);

--- a/src/Sensors/GPS/GPS.cpp
+++ b/src/Sensors/GPS/GPS.cpp
@@ -4,7 +4,7 @@ using namespace mmfs;
 
 #pragma region GPS Specific Functions
 
-GPS::GPS()
+GPS::GPS() : Sensor("GPS")
 {
     hr = 0;
     min = 0;
@@ -140,10 +140,6 @@ void GPS::findTimeZone()
 #pragma endregion // GPS Specific Functions
 
 #pragma region Sensor Virtual Function Implementations
-
-const char *GPS::getTypeString() const { return "GPS"; }
-
-const SensorType GPS::getType() const { return "GPS"_i; }
 
 void GPS::update()
 {

--- a/src/Sensors/GPS/GPS.cpp
+++ b/src/Sensors/GPS/GPS.cpp
@@ -143,7 +143,7 @@ void GPS::findTimeZone()
 
 const char *GPS::getTypeString() const { return "GPS"; }
 
-const SensorType GPS::getType() const { return GPS_; }
+const SensorType GPS::getType() const { return "GPS"_i; }
 
 void GPS::update()
 {

--- a/src/Sensors/GPS/GPS.h
+++ b/src/Sensors/GPS/GPS.h
@@ -22,9 +22,6 @@ namespace mmfs
         virtual void update() override;
         virtual bool begin(bool useBiasCorrection = true) override;
 
-        virtual const char *getTypeString() const override;
-        virtual const SensorType getType() const override;
-
         virtual const char *getTimeOfDay() const;
 
         virtual int8_t getHour() const;

--- a/src/Sensors/IMU/IMU.cpp
+++ b/src/Sensors/IMU/IMU.cpp
@@ -3,7 +3,7 @@
 namespace mmfs
 {
 
-    IMU::IMU()
+    IMU::IMU() : Sensor("IMU")
     {
         addColumn(DOUBLE, &measuredAcc.x(), "AccX (m/s^2)");
         addColumn(DOUBLE, &measuredAcc.y(), "AccY (m/s^2)");

--- a/src/Sensors/IMU/IMU.h
+++ b/src/Sensors/IMU/IMU.h
@@ -24,7 +24,7 @@ namespace mmfs
         virtual void setAccelBestFilteringAtStatic(double a) {accel_best_filtering_at_static = a;};
         virtual double getMagBestFilteringAtStatic() {return mag_best_filtering_at_static;};
         virtual void setMagBestFilteringAtStatic(double m) {mag_best_filtering_at_static = m;};
-        virtual const SensorType getType() const override { return IMU_; }
+        virtual const SensorType getType() const override { return "IMU"_i; }
         virtual const char *getTypeString() const override { return "IMU"; }
         virtual void update() override;
         virtual bool begin(bool useBiasCorrection = true) override;

--- a/src/Sensors/IMU/IMU.h
+++ b/src/Sensors/IMU/IMU.h
@@ -24,8 +24,6 @@ namespace mmfs
         virtual void setAccelBestFilteringAtStatic(double a) {accel_best_filtering_at_static = a;};
         virtual double getMagBestFilteringAtStatic() {return mag_best_filtering_at_static;};
         virtual void setMagBestFilteringAtStatic(double m) {mag_best_filtering_at_static = m;};
-        virtual const SensorType getType() const override { return "IMU"_i; }
-        virtual const char *getTypeString() const override { return "IMU"; }
         virtual void update() override;
         virtual bool begin(bool useBiasCorrection = true) override;
 

--- a/src/Sensors/LightSensor/LightSensor.cpp
+++ b/src/Sensors/LightSensor/LightSensor.cpp
@@ -17,7 +17,7 @@ namespace mmfs
 
 #pragma region Sensor Virtual Function Implementations
 
-    const SensorType LightSensor::getType() const { return LIGHT_SENSOR_; }
+    const SensorType LightSensor::getType() const { return "Light Sensor"_i; }
 
     const char *LightSensor::getTypeString() const { return "Light Sensor"; }
 

--- a/src/Sensors/LightSensor/LightSensor.cpp
+++ b/src/Sensors/LightSensor/LightSensor.cpp
@@ -4,7 +4,7 @@ namespace mmfs
 {
 #pragma region LightSensor Specific Functions
 
-    LightSensor::LightSensor() : lux(0), initialLux(0)
+    LightSensor::LightSensor() : lux(0), initialLux(0), Sensor("Light Sensor")
     {
         addColumn(DOUBLE, &lux, "Lux (Lux)");
     }
@@ -16,10 +16,6 @@ namespace mmfs
 #pragma endregion // LightSensor Specific Functions
 
 #pragma region Sensor Virtual Function Implementations
-
-    const SensorType LightSensor::getType() const { return "Light Sensor"_i; }
-
-    const char *LightSensor::getTypeString() const { return "Light Sensor"; }
 
     void LightSensor::update()
     {

--- a/src/Sensors/LightSensor/LightSensor.h
+++ b/src/Sensors/LightSensor/LightSensor.h
@@ -12,8 +12,6 @@ namespace mmfs
         virtual const double getLux() const;
 
         // Sensor virtual functions
-        virtual const SensorType getType() const override;
-        virtual const char *getTypeString() const override;
         virtual void update() override;
         virtual bool begin(bool useBiasCorrection = true) override;
 

--- a/src/Sensors/Sensor.h
+++ b/src/Sensors/Sensor.h
@@ -7,18 +7,11 @@
 #include "../RecordData/Logging/Logger.h"
 #include <algorithm>
 #include "../RecordData/DataReporter/DataReporter.h"
+#include "Utils/Hash.h"
 
 namespace mmfs
 {
-    enum SensorType // These have trailing underscores to avoid conflicts with the same names in other libraries *cough* IMU *cough*
-    {
-        BAROMETER_,
-        GPS_,
-        IMU_,
-        LIGHT_SENSOR_,
-        ENCODER_,
-        OTHER_
-    };
+    using SensorType = uint32_t;
 
     class Sensor : public DataReporter
     {

--- a/src/Sensors/Sensor.h
+++ b/src/Sensors/Sensor.h
@@ -25,8 +25,8 @@ namespace mmfs
         // Initializes the sensor and sets up any necessary parameters
         virtual bool begin(bool useBiasCorrection = true) = 0;
 
-        virtual const SensorType getType() const = 0;  // Returns the type of the sensor
-        virtual const char *getTypeString() const = 0; // Returns the type of the sensor as a string
+        virtual const SensorType getType() const { return type; }        // Returns the type of the sensor
+        virtual const char *getTypeString() const { return typeString; } // Returns the type of the sensor as a string
 
         // ------------------------------- BASE SENSOR CLASS IMPLEMENTATION ----------------------------------------
     public:
@@ -42,7 +42,11 @@ namespace mmfs
 
     protected:
         // --------------------------------- HARDWARE IMPLEMENTATION -----------------------------------------------
-
+        Sensor(const char *type)
+        {
+            this->type = fnv1a_32(type, strlen(type));
+            typeString = type;
+        }
         // Sets up the sensor and stores any critical parameters. Needs to reset the sensor if it is already initialized. Called by begin()
         virtual bool init() = 0;
         // Physically reads the outputs from the sensor hardware. Called by update()
@@ -51,6 +55,9 @@ namespace mmfs
         // ----------------------------------------------------------------------------------------------------------
         bool initialized = false;
         bool biasCorrectionMode = true;
+
+        SensorType type;
+        const char *typeString;
 
         const int CIRC_BUFFER_LENGTH = UPDATE_RATE * SENSOR_BIAS_CORRECTION_DATA_LENGTH; // number of entries to give SBCDL length average
         const int CIRC_BUFFER_IGNORE = UPDATE_RATE * SENSOR_BIAS_CORRECTION_DATA_IGNORE; // number of entries to ignore for SBCD

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -100,8 +100,8 @@ namespace mmfs
 
     void State::updateVariables()
     {
-        GPS *gps = reinterpret_cast<GPS *>(getSensor(GPS_));
-        IMU *imu = reinterpret_cast<IMU *>(getSensor(IMU_));
+        GPS *gps = reinterpret_cast<GPS *>(getSensor("GPS"_i));
+        IMU *imu = reinterpret_cast<IMU *>(getSensor("IMU"_i));
         // Barometer *baro = reinterpret_cast<Barometer *>(getSensor(BAROMETER_));
 
         if (filter)
@@ -126,9 +126,9 @@ namespace mmfs
     void State::updateWithoutKF()
     {
 
-        GPS *gps = reinterpret_cast<GPS *>(getSensor(GPS_));
-        IMU *imu = reinterpret_cast<IMU *>(getSensor(IMU_));
-        Barometer *baro = reinterpret_cast<Barometer *>(getSensor(BAROMETER_));
+        GPS *gps = reinterpret_cast<GPS *>(getSensor("GPS"_i));
+        IMU *imu = reinterpret_cast<IMU *>(getSensor("IMU"_i));
+        Barometer *baro = reinterpret_cast<Barometer *>(getSensor("Barometer"_i));
 
         if (sensorOK(gps))
             position = gps->getDisplacement();
@@ -146,10 +146,9 @@ namespace mmfs
 
     void State::updateKF()
     {
-
-        GPS *gps = reinterpret_cast<GPS *>(getSensor(GPS_));
-        IMU *imu = reinterpret_cast<IMU *>(getSensor(IMU_));
-        Barometer *baro = reinterpret_cast<Barometer *>(getSensor(BAROMETER_));
+        GPS *gps = reinterpret_cast<GPS *>(getSensor("GPS"_i));
+        IMU *imu = reinterpret_cast<IMU *>(getSensor("IMU"_i));
+        Barometer *baro = reinterpret_cast<Barometer *>(getSensor("Barometer"_i));
 
         double *measurements = new double[filter->getMeasurementSize()];
         double *inputs = new double[filter->getInputSize()];

--- a/src/Utils/Hash.h
+++ b/src/Utils/Hash.h
@@ -1,0 +1,22 @@
+#ifndef HASH_H
+#define HASH_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+constexpr uint32_t fnv1a_32(const char *s, size_t count)
+{
+    uint32_t hash = 2166136261u;
+    for (size_t i = 0; i < count; i++)
+    {
+        hash ^= static_cast<unsigned char>(s[i]);
+        hash *= 16777619u;
+    }
+    return hash;
+}
+constexpr uint32_t operator"" _i(const char *str, size_t len)
+{
+    return fnv1a_32(str, len);
+}
+
+#endif

--- a/test/test_sensor/TestSensor.cpp
+++ b/test/test_sensor/TestSensor.cpp
@@ -1,0 +1,47 @@
+#include <unity.h>
+#include "../../lib/NativeTestMocks/NativeTestHelper.h"
+
+// include other headers you need to test here
+
+#include "../../lib/NativeTestMocks/UnitTestSensors.h"
+
+// ---
+
+// Set up and global variables or mocks for testing here
+
+// ---
+
+// These two functions are called before and after each test function, and are required in unity, even if empty.
+void setUp(void)
+{
+    // set stuff up before each test here, if needed
+}
+
+void tearDown(void)
+{
+    // clean stuff up after each test here, if needed
+}
+// ---
+
+// Test functions must be void and take no arguments, put them here
+
+void test_constructor() {
+    FakeBarometer fake;
+    TEST_ASSERT_EQUAL_STRING("FakeBarometer", fake.getName());
+    TEST_ASSERT_EQUAL_STRING("Barometer", fake.getTypeString());
+    TEST_ASSERT_EQUAL_INT32("Barometer"_i, fake.getType());
+}
+
+// ---
+
+// This is the main function that runs all the tests. It should be the last thing in the file.
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+
+    // Add your tests here
+    RUN_TEST(test_constructor); // no parentheses after function name
+
+    UNITY_END();
+}
+// ---


### PR DESCRIPTION
reworked SensorType to now be a `uint32_t`, which can be easily found using the same hashing system that events use.

When you create a new type of sensor, pass the type as a string to the Sensor constructor.

Then, you can use getTypeString and getType from and child class without having to override them yourself.

```cpp
        Sensor(const char *type)
        {
            this->type = fnv1a_32(type, strlen(type));
            typeString = type;
        }
        
Barometer::Barometer() : Sensor("Barometer") {}

//from the unit tests:

void test_constructor() {
    FakeBarometer fake;
    TEST_ASSERT_EQUAL_STRING("FakeBarometer", fake.getName());
    TEST_ASSERT_EQUAL_STRING("Barometer", fake.getTypeString());
    TEST_ASSERT_EQUAL_INT32("Barometer"_i, fake.getType());
}

//the only thing FakeBarometer sets on its own is the name.
```
            